### PR TITLE
Add xmlns to exported SVG files.

### DIFF
--- a/inc/drawing.js
+++ b/inc/drawing.js
@@ -93,7 +93,7 @@ function prepareFiles(midiData) {
 	var model = returnArray[0];
 	var origins = returnArray[1];
 	
-	fileTexts["svg"] = makerjs.exporter.toSVG(model, {units: units, useSvgPathOnly: false});
+	fileTexts["svg"] = makerjs.exporter.toSVG(model, {units: units, useSvgPathOnly: false, svgAttrs: {xmlns: "http://www.w3.org/2000/svg"}});
 	fileTexts["dxf"] = makerjs.exporter.toDXF(model, {units : units});
 	fileTexts["txt"] = origins;
 	document.getElementById("preview-box").innerHTML = fileTexts["svg"];


### PR DESCRIPTION
This allows the file to be recognized as SVG by Chrome so it displays the image instead of the XML source, and by the W3C Validator (https://validator.w3.org/).

Note: I didn't see directions for building the application so I wasn't able to test this, but I believe that it should work.