### PR TITLE
remove note if clicked

### DIFF
--- a/experimental/musicboxeditor/src/app/app.component.html
+++ b/experimental/musicboxeditor/src/app/app.component.html
@@ -94,7 +94,7 @@
         <text class="note" *ngFor="let ns of noteScale" (click)="onClickScale($event, ns)" style="font-size: 1mm; vertical-align: middle;" text-anchor="start" x="2" [attr.y]="getTextY(ns)" [textContent]="midiToNote(ns)"></text>
       </svg>  
       <div class="track">
-        <svg id="musicbox-svg" *ngIf="showTrack()" [attr.width]="getViewBoxWidth()" [attr.height]="getViewBoxHeight()" [attr.viewBox]="getTrackViewBox()" (click)="onClickSvg($event)" (mouseenter)="onMouseEnterSvg($event)" (mouseleave)="onMouseLeaveSvg($event)" (mousemove)="onMouseOverSvg($event)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
+        <svg id="musicbox-svg" *ngIf="showTrack()" [attr.width]="getViewBoxWidth()" [attr.height]="getViewBoxHeight()" [attr.viewBox]="getTrackViewBox()" (mouseup)="onMouseUpSvg($event)" (mouseenter)="onMouseEnterSvg($event)" (mouseleave)="onMouseLeaveSvg($event)" (mousemove)="onMouseOverSvg($event)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
           <!--Pattern-->
           <defs id="defs">
             <pattern id="map" width="8" height="3" patternUnits="userSpaceOnUse">
@@ -124,10 +124,10 @@
           <!--Notes-->
           <g id="notes">
             <template [ngIf]="isCircleNoteType()">
-              <ellipse *ngFor="let n of notes" [hint]="getHint(n)" (contextmenu)="onClickContextMenu($event, n)" [attr.fill]="getNoteFillColor(n)" stroke="#000" stroke-width="0.5" [attr.cx]="getNoteX(n)" [attr.cy]="getNoteY(n)" [attr.rx]="getNoteWidth(n)" [attr.ry]="getNoteHeight()" />
+              <ellipse *ngFor="let n of notes" (mousedown)="onMouseDownNote(n)" [hint]="getHint(n)" (contextmenu)="onClickContextMenu($event, n)" [attr.fill]="getNoteFillColor(n)" stroke="#000" stroke-width="0.5" [attr.cx]="getNoteX(n)" [attr.cy]="getNoteY(n)" [attr.rx]="getNoteWidth(n)" [attr.ry]="getNoteHeight()" />
             </template>
             <template [ngIf]="!isCircleNoteType()">
-              <rect *ngFor="let n of notes" [hint]="getHint(n)" (contextmenu)="onClickContextMenu($event, n)" [attr.fill]="getNoteFillColor(n)" stroke="#000" stroke-width="0.5" [attr.x]="getNoteX(n)" [attr.y]="getNoteY(n)" [attr.width]="getNoteWidth(n)" [attr.height]="getNoteHeight()" />
+              <rect *ngFor="let n of notes" (mousedown)="onMouseDownNote(n)" [hint]="getHint(n)" (contextmenu)="onClickContextMenu($event, n)" [attr.fill]="getNoteFillColor(n)" stroke="#000" stroke-width="0.5" [attr.x]="getNoteX(n)" [attr.y]="getNoteY(n)" [attr.width]="getNoteWidth(n)" [attr.height]="getNoteHeight()" />
             </template>
           </g>
 

--- a/experimental/musicboxeditor/src/app/app.component.ts
+++ b/experimental/musicboxeditor/src/app/app.component.ts
@@ -32,6 +32,7 @@ export class AppComponent {
     header: IHeader;
     notes: INote[];
     ghostNote: INote = null;
+    removingNote: boolean = false;
 
     /*
         C  |C# |D  |D# |E  |F  |F# |G  |G# |A  |A# |B 
@@ -516,12 +517,23 @@ Or right click on note to delete it.
     onMouseLeaveSvg(event: MouseEvent){
         this.ghostNote = null;
         event.preventDefault();
-    }   
+    }
 
-    onClickSvg(event: MouseEvent){
-        this.notes.push(this.ghostNote);
-        this.sortNotes();
-        this.createGhostNote();
+    onMouseDownNote(note: INote){
+        this.removingNote = true;
+        let i = this.notes.indexOf(note);
+        this.notes.splice(i, 1);
+        event.preventDefault();
+    }
+
+    onMouseUpSvg(event: MouseEvent){
+        if (!this.removingNote) {
+            this.notes.push(this.ghostNote);
+            this.sortNotes();
+            this.createGhostNote();
+        } else {
+            this.removingNote = false;
+        }
         event.preventDefault();
     }
 


### PR DESCRIPTION
Notes are now added after a `mouseup` event instead of `click`.

When a `mousedown` event occurs on a note, that note is removed from the `notes` array, deleting it from the GUI.

The `removingNote` attribute is used to prevent a new note from being created when the mouse button is released after deleting a note.